### PR TITLE
[MSDK-3366] Fix swallowed messages bug

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -14,8 +14,8 @@ buildscript {
     ext.kotlin_version = '1.3.0'
 
     repositories {
-        jcenter()
         google()
+        jcenter()
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:3.2.1'

--- a/chat_api_sample/src/main/java/com/zopim/sample/chatapi/chat/ChatPresenter.java
+++ b/chat_api_sample/src/main/java/com/zopim/sample/chatapi/chat/ChatPresenter.java
@@ -11,7 +11,7 @@ import java.util.List;
 import java.util.Map;
 
 /**
- * Bridge code between {@link ChatPresenter} and {@link ChatView}.
+ * Bridge code between {@link ChatModel} and {@link ChatView}.
  */
 class ChatPresenter implements ChatMvp.Presenter {
 


### PR DESCRIPTION
## Changes
Fix swallowed messages bug

Calling `DataSource#removeObservers()` removes all observers, including our internal that transitions between modes based on connection state. This causes chat state to stuck in INITIALIZING mode forever. As a result, an user is unable to send and receive messages. 

We advice not to call this method at all and unregister each observer individually as done in this PR.

### Reviewers
@zendesk/adventure-android @zendesk/two-brothers-android @zendesk/atom-android @baz8080 @a1cooke