### PR TITLE
Disabling Firebase app auto init

### DIFF
--- a/chat_api_sample/src/main/AndroidManifest.xml
+++ b/chat_api_sample/src/main/AndroidManifest.xml
@@ -11,6 +11,11 @@
         android:supportsRtl="true"
         android:theme="@style/AppTheme">
 
+        <provider android:authorities="${applicationId}.firebaseinitprovider"
+            android:name="com.google.firebase.provider.FirebaseInitProvider"
+            android:exported="false"
+            tools:node="remove"/>
+
         <activity android:name=".MainActivity">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN"/>

--- a/chat_sample/src/main/AndroidManifest.xml
+++ b/chat_sample/src/main/AndroidManifest.xml
@@ -11,6 +11,12 @@
         android:label="@string/app_name"
         android:theme="@style/AppTheme"
         tools:replace="android:label">
+
+        <provider android:authorities="${applicationId}.firebaseinitprovider"
+            android:name="com.google.firebase.provider.FirebaseInitProvider"
+            android:exported="false"
+            tools:node="remove"/>
+
         <activity
             android:name=".EntryActivity"
             android:label="@string/app_name"

--- a/scripts/shell/travis.sh
+++ b/scripts/shell/travis.sh
@@ -15,7 +15,7 @@ boxOut(){
 
 acceptLicenses() {
     mkdir -p ${ANDROID_HOME}licenses
-    echo -e "\nd56f5187479451eabf01fb78af6dfcb131a6481e" > ${ANDROID_HOME}licenses/android-sdk-license
+    echo -e "\nd56f5187479451eabf01fb78af6dfcb131a6481e\n24333f8a63b6825ea9c5514f83c2829b004d1fee" > ${ANDROID_HOME}licenses/android-sdk-license
 }
 
 buildAll() {


### PR DESCRIPTION
## Changes
* Disables the firebase app init provider in both chat sample apps

This is required because we attempt to manually init the firebase app without the `google-services.json` file. Firebase will automatically try to init and fail because the file doesn't exist

### Reviewers
@zendesk/adventure-android @zendesk/two-brothers-android @zendesk/atom-android @baz8080 @a1cooke