### PR TITLE
Upgrade Answer Bot SDK to 1.0.0-EAP2

### DIFF
--- a/answerbot_sample/build.gradle
+++ b/answerbot_sample/build.gradle
@@ -22,7 +22,7 @@ android {
 }
 
 dependencies {
-    api group: 'com.zendesk', name: 'answerbot', version: '1.0.0-EAP1'
+    api group: 'com.zendesk', name: 'answerbot', version: rootProject.ext.answerBotSdkVersion
     implementation group: 'com.zendesk', name: 'support', version: rootProject.ext.zendeskSdkVersion
     implementation project(":demo_apps_commons")
 }

--- a/build.gradle
+++ b/build.gradle
@@ -8,11 +8,12 @@ ext {
     zendeskSdkVersion = "2.3.1"
     zopimSdkVersion = "1.4.4"
     connectSdkVersion = "2.0.0"
+    answerBotSdkVersion = "1.0.0-EAP2"
     appCompatVersion = "28.0.0"
 }
 
 buildscript {
-    ext.kotlin_version = '1.3.21'
+    ext.kotlin_version = '1.3.30'
 
     repositories {
         google()


### PR DESCRIPTION
## Changes
* Extract Answer Bot version and bump to EAP2

## Notes
* This should fail to build until Answer Bot SDK EAP2 is published

### Reviewers
@zendesk/adventure-android @zendesk/two-brothers-android @zendesk/atom-android @baz8080 @a1cooke