### PR TITLE
Update Talk SDK dependency to 1.1.0 in talk sample

### DIFF
--- a/talk_sample/build.gradle
+++ b/talk_sample/build.gradle
@@ -38,7 +38,7 @@ android {
 
 dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
-    implementation "zendesk.talk:talk-android:1.0.0"
+    implementation "zendesk.talk:talk-android:1.1.0"
     implementation 'androidx.constraintlayout:constraintlayout:2.0.4'
     implementation "androidx.lifecycle:lifecycle-runtime-ktx:2.2.0"
     implementation project(":demo_apps_commons")


### PR DESCRIPTION
## Changes
* Update dependency of Talk SDK to recent release

### Reviewers
* @zendesk/banshee-android